### PR TITLE
[CIR-2448-Refactor] Improve the error handling in the connector, make the response match the ErrorSchema in the OpenAPI spec

### DIFF
--- a/app/uk/gov/hmrc/phonenumbergateway/models/Error.scala
+++ b/app/uk/gov/hmrc/phonenumbergateway/models/Error.scala
@@ -32,7 +32,7 @@ case object MissingCorrelationId extends Error("MISSING_CORRELATION_ID", s"${Con
 object Error {
   implicit val writes: Writes[Error] = Writes { model =>
     Json.obj(
-      "status" -> model.code,
+      "statusCode" -> model.code,
       "message" -> model.desc
     )
   }

--- a/app/uk/gov/hmrc/phonenumbergateway/models/Error.scala
+++ b/app/uk/gov/hmrc/phonenumbergateway/models/Error.scala
@@ -21,12 +21,18 @@ import uk.gov.hmrc.phonenumbergateway.config.Constants
 
 sealed class Error(val code: String, val desc: String)
 
+case object DownstreamError extends Error("REQUEST_DOWNSTREAM", "An issue occurred when the downstream service tried to handle the request")
+
+case object RequestForwardingError extends Error("REQUEST_FORWARDING", "An issue occurred when forwarding the request to the downstream service")
+
+case object UnsupportedMethodError extends Error("UNSUPPORTED_METHOD", "Unsupported HTTP method")
+
 case object MissingCorrelationId extends Error("MISSING_CORRELATION_ID", s"${Constants.xCorrelationId} header is missing from the request")
 
 object Error {
   implicit val writes: Writes[Error] = Writes { model =>
     Json.obj(
-      "statusCode" -> model.code,
+      "status" -> model.code,
       "message" -> model.desc
     )
   }

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -57,12 +57,12 @@ paths:
                 invalidPhoneNumber:
                   summary: Invalid telephone number example
                   value:
-                    status: "VALIDATION_ERROR"
+                    statusCode: "VALIDATION_ERROR"
                     message: "Enter a valid telephone number"
                 onlyMobileAllowed:
                   summary: Only mobile numbers can be verified example
                   value:
-                    status: "VALIDATION_ERROR"
+                    statusCode: "VALIDATION_ERROR"
                     message: "Only mobile numbers can be verified"
         '5XX':
           description: |
@@ -110,12 +110,12 @@ paths:
                 enterValidVerificationCode:
                   summary: Invalid verification code example
                   value:
-                    status: "VALIDATION_ERROR"
+                    statusCode: "VALIDATION_ERROR"
                     message: "Enter a valid verification code"
                 enterValidPhoneNumberVerificationCode:
                   summary: Invalid phone number or verification code example
                   value:
-                    status: "VALIDATION_ERROR"
+                    statusCode: "VALIDATION_ERROR"
                     message: "Enter a valid telephone number/verification code"
         '404':
           description: Verification code not found
@@ -169,7 +169,7 @@ paths:
                 missingCorrelationId:
                   summary: Missing X-Correlation-ID Header
                   value:
-                    status: "MISSING_CORRELATION_ID"
+                    statusCode: "MISSING_CORRELATION_ID"
                     message: "X-Correlation-ID header is missing from the request"
         '403':
           description: Authorisation errors
@@ -181,7 +181,7 @@ paths:
                 userNotAllowed:
                   summary: User not allowed
                   value:
-                    status: "USER_NOT_ALLOWED"
+                    statusCode: "USER_NOT_ALLOWED"
                     message: "One or more user agents in 'some-service' are not authorized to use this service."
         '502':
           description: Downstream service issues
@@ -193,7 +193,7 @@ paths:
                 downstreamError:
                   summary: Issue on Downstream Gateway
                   value:
-                    status: "REQUEST_DOWNSTREAM"
+                    statusCode: "REQUEST_DOWNSTREAM"
                     message: "An unrecoverable error occurred when the downstream service tried to handle the request"
         '5XX':
           description: |
@@ -218,7 +218,7 @@ components:
     errorResponse:
       type: object
       properties:
-        status:
+        statusCode:
           type: string
           description: The type of error returned.
           example: "VALIDATION_ERROR"

--- a/test/uk/gov/hmrc/phonenumbergateway/controllers/VerifyControllerSpec.scala
+++ b/test/uk/gov/hmrc/phonenumbergateway/controllers/VerifyControllerSpec.scala
@@ -30,6 +30,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.core.server.{Server, ServerConfig}
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.phonenumbergateway.models.{DownstreamError, Error}
 
 class VerifyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
   val insightsPort = 11222
@@ -101,7 +102,6 @@ class VerifyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
     }
 
     "return bad gateway if there is no connectivity to the downstream service" in {
-      val errorResponse = """{"code": "REQUEST_DOWNSTREAM", "desc": "An issue occurred when the downstream service tried to handle the request"}""".stripMargin
 
       val fakeRequest = FakeRequest("POST", "/phone-number-gateway/send-code")
         .withBody(Json.parse("""{"phoneNumber": "12123123456"}"""))
@@ -109,7 +109,7 @@ class VerifyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
 
       val result = controller.any()(fakeRequest)
       status(result) shouldBe Status.BAD_GATEWAY
-      contentAsString(result) shouldBe errorResponse
+      contentAsJson(result) shouldBe Json.toJson[Error](DownstreamError)
     }
 
   }
@@ -175,7 +175,6 @@ class VerifyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
     }
 
     "return bad gateway if there is no connectivity to the downstream service" in {
-      val errorResponse = """{"code": "REQUEST_DOWNSTREAM", "desc": "An issue occurred when the downstream service tried to handle the request"}""".stripMargin
 
       val fakeRequest = FakeRequest("POST", "/phone-number-gateway/verify-code")
         .withBody(Json.parse("""{"phoneNumber": "12123123456",  "no-verification-code": "ABCGED"}"""))
@@ -183,7 +182,7 @@ class VerifyControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPer
 
       val result = controller.any()(fakeRequest)
       status(result) shouldBe Status.BAD_GATEWAY
-      contentAsString(result) shouldBe errorResponse
+      contentAsJson(result) shouldBe Json.toJson[Error](DownstreamError)
     }
 
   }


### PR DESCRIPTION
This pull request refactors error handling in the `DownstreamConnector` to use structured JSON responses and new error model objects, improving consistency and testability. It replaces hardcoded error strings with instances of the `Error` model, updates the error serialization format, and adapts tests to match the new error response structure.

**Error handling improvements:**

* Introduced new error model objects: `DownstreamError`, `RequestForwardingError`, and `UnsupportedMethodError` in `Error.scala`, replacing previous hardcoded error strings.
* Refactored `DownstreamConnector` to use these error model objects and Play's JSON serialization for error responses, ensuring all downstream errors are returned as structured JSON. [[1]](diffhunk://#diff-c3252930bb2161ac04fa4d8d038649e38021a504fb353e023b827a2c3a9b8901L21-R27) [[2]](diffhunk://#diff-c3252930bb2161ac04fa4d8d038649e38021a504fb353e023b827a2c3a9b8901L57-R69)

**Error response format changes:**

* Changed the error JSON format: the top-level field is now `"status"` instead of `"code"`, and `"message"` instead of `"desc"`, for all error responses.

**Test updates:**

* Updated tests in `VerifyControllerSpec.scala` to expect the new structured JSON error responses using the error model objects, rather than matching string representations. [[1]](diffhunk://#diff-04ce0afb5413c12e9bfa6aa1d5add3eb65eb01c5d4c2e6c737f3796197313688R33) [[2]](diffhunk://#diff-04ce0afb5413c12e9bfa6aa1d5add3eb65eb01c5d4c2e6c737f3796197313688L104-R112) [[3]](diffhunk://#diff-04ce0afb5413c12e9bfa6aa1d5add3eb65eb01c5d4c2e6c737f3796197313688L178-R185)